### PR TITLE
add Node version to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Featuring various modes:
 Big thanks to @elliottate for helping out with this!
 
 ## Development
-
+**Prerequisites: Node v11.15.0**
 ```
 npm install
 npm run start

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Featuring various modes:
 Big thanks to @elliottate for helping out with this!
 
 ## Development
+
 ```
 npm install
 npm run start

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Featuring various modes:
 Big thanks to @elliottate for helping out with this!
 
 ## Development
-**Prerequisites: Node v11.15.0**
 ```
 npm install
 npm run start

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
+    "preinstall": "npx ensure-node-env",
     "build": "cross-env NODE_ENV=production webpack",
     "deploy": "npm run predeploy && ghpages git@github.com:supermedium/moonrider.git -p .ghpages && rm -rf .ghpages",
     "lint": "semistandard -v | snazzy",
@@ -53,6 +54,7 @@
     "babel-preset-minify": "^0.5.0",
     "css-loader": "^0.28.7",
     "debug": "^4.1.0",
+    "ensure-node-env": "^1.2.3",
     "firebase": "^5.9.2",
     "html-require-loader": "^1.0.1",
     "ip": "1.1.5",
@@ -87,6 +89,7 @@
     ]
   },
   "engines": {
-    "node": "8.9.1"
+    "node": "<=11.15.0",
+    "npm": "<=6.7.0"
   }
 }


### PR DESCRIPTION
There are errors when running `npm i` on Node v`12.2.0` and `12.3.0`, but `11.15` works fine.  #26 

The latest working Node version should be specified in README instructions. 