### PR TITLE
Block raycast on some elements (ground, rank letter, leaderboard background)

### DIFF
--- a/src/templates/leaderboard.html
+++ b/src/templates/leaderboard.html
@@ -10,6 +10,7 @@
   render-order="menuitem">
 
   <a-entity
+    raycastable
     id="leaderboardBackground" position="0 0 0"
     geometry="primitive: plane; width: 2; height: 2"
     material="shader: panelShader; ratio: 1.16; brightness: 0.2"></a-entity>

--- a/src/templates/victory.html
+++ b/src/templates/victory.html
@@ -14,6 +14,7 @@
     render-order="victory"></a-entity>
 
   <a-entity
+    raycastable
     id="victoryInfoRank"
     class="accuracyTextCounterSubscribe"
     bind__animation="enabled: isVictory"


### PR DESCRIPTION
This PR aims to resolve issue #40 

It works perfectly for the rank letter.

It works for the leader background but it is blocking even if the leaderboard is not visible (for example before starting a song).

For the ground, I couldn't make it work. I tried to add `raycastable` to the curve object but it blocks the raycast in a kind of random way.

Feel free to send your suggestions :)