### PR TITLE
Improve blade collision by using triangles instead of bbox for blade.

### DIFF
--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -449,7 +449,7 @@ AFRAME.registerComponent('beat', {
         this.bladeLocalTriangles [1].set(this.bladeLocalPositions [2], this.bladeLocalPositions [3], this.bladeLocalPositions [0]);
 
         const beatBbox = this.blockEl.getObject3D('mesh').geometry.boundingBox;
-        if (!beatBbox.intersectsTriangle(this.bladeLocalTriangles [0]) && !beatBbox.intersectsTriangle(this.bladeLocalTriangles [0])) {
+        if (!beatBbox.intersectsTriangle(this.bladeLocalTriangles [0]) && !beatBbox.intersectsTriangle(this.bladeLocalTriangles [1])) {
           continue;
         }
       }

--- a/src/components/blade.js
+++ b/src/components/blade.js
@@ -18,6 +18,12 @@ AFRAME.registerComponent('blade', {
     this.rigEl = document.getElementById('curveFollowRig');
     this.strokeDirectionVector = new THREE.Vector3();
     this.strokeSpeed = 0;
+    this.bladeWorldPositions = [
+      new THREE.Vector3(),
+      new THREE.Vector3(),
+      new THREE.Vector3(),
+      new THREE.Vector3(),
+    ];
 
     this.bladeEl = this.el.querySelector('.blade');
   },
@@ -45,6 +51,10 @@ AFRAME.registerComponent('blade', {
     const bladeObj = this.el.object3D;
     bladeObj.localToWorld(this.bladeTipPosition);
     bladeObj.localToWorld(this.bladePosition);
+    this.bladeWorldPositions [2].copy(this.bladeWorldPositions [0]);
+    this.bladeWorldPositions [3].copy(this.bladeWorldPositions [1]);
+    this.bladeWorldPositions [0].copy(this.bladeTipPosition);
+    this.bladeWorldPositions [1].copy(this.bladePosition);
     rig.worldToLocal(this.bladeTipPosition);
     rig.worldToLocal(this.bladePosition);
 


### PR DESCRIPTION
This patch aims to improve the collision detection of the blades in classis mode.

Previously the collision was detected as a intersection of the world-axis-aligned bounding boxes of both the blade and the beat. I was under the impression that the blade's bounding box was quite huge if the blade is tilted leading to some missed or bad cuts that should have hit. In addition to that quick movements of the blades on the Oculus quest caused to go right through the beat without triggering a collision because the blade was above the beat in one frame and below the beat in another.

This patch proposes to change the collision detection from the blade's AABB to a set of triangles spanning the area the blade  has been between this frame and the last. This set of triangles is projected into the local coordinate space of the beat to check against the mesh's bounding box.