### PR TITLE
Oculus go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ exports/
 dump.rdb
 .ghpages
 package-lock.json
+
+#Idea Project Files
+idea/
+.idea/

--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -503,7 +503,9 @@ AFRAME.registerComponent('beat', {
     const data = this.data;
 
     // Haptics.
-    weaponEl.components.haptics__beat.pulse();
+    if(AFRAME.utils.device.isMobile()) {
+      weaponEl.components.haptics__beat.pulse();
+    }
 
     // Sound.
     this.el.parentNode.components['beat-hit-sound'].playSound(this.el, this.cutDirection);

--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -503,8 +503,10 @@ AFRAME.registerComponent('beat', {
     const data = this.data;
 
     // Haptics.
-    if(AFRAME.utils.device.isMobile()) {
+    try{
       weaponEl.components.haptics__beat.pulse();
+    } catch (err){
+      console.log(err);
     }
 
     // Sound.


### PR DESCRIPTION
Wrapped pulse in beat.js (505) in try and catch. To prevent oculus go from crashing on block hit.