### PR TITLE
UX: Make 'exit to menu' show current challenge.

### DIFF
--- a/src/state/index.js
+++ b/src/state/index.js
@@ -369,6 +369,8 @@ AFRAME.registerState({
       state.isPaused = false;
       state.isVictory = false;
       state.menuActive = true;
+      state.menuSelectedChallenge.id = state.challenge.id;
+      state.menuSelectedChallenge.difficulty = state.challenge.difficulty;
       state.challenge.id = '';
       state.leaderboardQualified = false;
     },


### PR DESCRIPTION
After playing a challenge I find that I often want to either click
favorite or play the challenge again but at a different difficulty level.
In both cases I currently have to (a) remember the name of the song
I just exited and (2) find it in the song list and click it again.
Which resets the difficulty, so I also have to remember which difficulty
level I just played if I want to try a different one.

This simple patch makes the {EXIT,BACK} TO MENU buttons return to the
view of the menu that has the current challenge selected.  It is then a
simple matter to click favorite or choose a different difficulty level.
No usability is lost by this change, since the list of songs is
displayed on the left.  If what one wants to do next is select another
song, that is still only a single click, but now you can also see which
song it was you just played, so if you are wanting the next one, it is
easier to find it.