### PR TITLE
UX: use saved difficulty when selecting a favorite.

### DIFF
--- a/src/state/index.js
+++ b/src/state/index.js
@@ -476,6 +476,8 @@ AFRAME.registerState({
           state.menuDifficulties.indexOf(state.difficultyFilter) !== -1) {
         // Default to difficulty if filter active.
         state.menuSelectedChallenge.difficulty = state.difficultyFilter;
+      } else if (state.menuDifficulties.indexOf(state.menuSelectedChallenge.difficulty) !== -1) {
+        // Use difficulty if already set (ie: challenge came from favorites)
       } else {
         // Default to easiest difficulty.
         state.menuSelectedChallenge.difficulty = state.menuDifficulties[0];


### PR DESCRIPTION
Difficulty levels are all well and good, but they are always a judgement
call.  For me a 'favorite' song also includes a favorite difficulty
level.  This patch uses the difficulty level that was selected when the
song was favorited if the song being selected is a favorite.

This doesn't work 100%, though.  The *first* song selected from the
favorites list still defaults to the easiest difficulty.  If you click
another favorite and then click back it picks up the saved difficulty.
I can't figure out how that fist click is failing to use the saved
difficulty.

An obvious followon here would be a 'save' button for changing the saved
difficulty level, but I'm not sure how to make it intuitive in the UI what
the purpose of that button would be.  In the meantime you can do it by
unfavoriting and favoriting again.