### PR TITLE
Update moonrider to aframe 1.0.4

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta property="twitter:image" content="https://supermedium.com/moonrider/assets/img/splash.jpg">
 
     <link rel="shortcut icon" href="assets/img/favicon.png" type="image/x-icon">
-    <script src="https://aframe.io/releases/0.9.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
     <script src="build/build.js"></script>
   </head>
   <body>

--- a/src/components/supercurve.js
+++ b/src/components/supercurve.js
@@ -159,13 +159,13 @@ AFRAME.registerComponent('supercurve', {
       }
     }
 
-    geometry.addAttribute('normal', new THREE.BufferAttribute(buffers.normal, 3));
-    geometry.addAttribute('position', new THREE.BufferAttribute(buffers.position, 3));
-    geometry.addAttribute('uv', new THREE.BufferAttribute(buffers.uvs, 2));
+    geometry.setAttribute('normal', new THREE.BufferAttribute(buffers.normal, 3));
+    geometry.setAttribute('position', new THREE.BufferAttribute(buffers.position, 3));
+    geometry.setAttribute('uv', new THREE.BufferAttribute(buffers.uvs, 2));
 
     // Set mesh.
     if (el.getObject3D('mesh')) {
-      el.getObject3D('mesh').geometry = geometry;
+      el.getObject3D('mesh').geometry = THREE.BufferGeometryUtils.toTrianglesDrawMode(geometry, THREE.TriangleStripDrawMode);
     } else {
       const mesh = new THREE.Mesh(THREE.BufferGeometryUtils.toTrianglesDrawMode(geometry, THREE.TriangleStripDrawMode));
       el.setObject3D('mesh', mesh);

--- a/src/components/supercurve.js
+++ b/src/components/supercurve.js
@@ -167,8 +167,7 @@ AFRAME.registerComponent('supercurve', {
     if (el.getObject3D('mesh')) {
       el.getObject3D('mesh').geometry = geometry;
     } else {
-      const mesh = new THREE.Mesh(geometry);
-      mesh.drawMode = THREE.TriangleStripDrawMode;
+      const mesh = new THREE.Mesh(THREE.BufferGeometryUtils.toTrianglesDrawMode(geometry, THREE.TriangleStripDrawMode));
       el.setObject3D('mesh', mesh);
     }
   },

--- a/vendor/BufferGeometryUtils.js
+++ b/vendor/BufferGeometryUtils.js
@@ -391,6 +391,117 @@ THREE.BufferGeometryUtils = {
 
 		return new THREE.BufferAttribute( array, itemSize, normalized );
 
+	},
+
+	/**
+	 * @param {BufferGeometry} geometry
+	 * @param {number} drawMode
+	 * @return {BufferGeometry>}
+	 */
+	toTrianglesDrawMode: function ( geometry, drawMode ) {
+
+		if ( drawMode === THREE.TrianglesDrawMode ) {
+
+			console.warn( 'THREE.BufferGeometryUtils.toTrianglesDrawMode(): Geometry already defined as triangles.' );
+			return geometry;
+
+		}
+
+		if ( drawMode === THREE.TriangleFanDrawMode || drawMode === THREE.TriangleStripDrawMode ) {
+
+			var index = geometry.getIndex();
+
+			// generate index if not present
+
+			if ( index === null ) {
+
+				var indices = [];
+
+				var position = geometry.getAttribute( 'position' );
+
+				if ( position !== undefined ) {
+
+					for ( var i = 0; i < position.count; i ++ ) {
+
+						indices.push( i );
+
+					}
+
+					geometry.setIndex( indices );
+					index = geometry.getIndex();
+
+				} else {
+
+					console.error( 'THREE.BufferGeometryUtils.toTrianglesDrawMode(): Undefined position attribute. Processing not possible.' );
+					return geometry;
+
+				}
+
+			}
+
+			//
+
+			var numberOfTriangles = index.count - 2;
+			var newIndices = [];
+
+			if ( drawMode === THREE.TriangleFanDrawMode ) {
+
+				// gl.TRIANGLE_FAN
+
+				for ( var i = 1; i <= numberOfTriangles; i ++ ) {
+
+					newIndices.push( index.getX( 0 ) );
+					newIndices.push( index.getX( i ) );
+					newIndices.push( index.getX( i + 1 ) );
+
+				}
+
+			} else {
+
+				// gl.TRIANGLE_STRIP
+
+				for ( var i = 0; i < numberOfTriangles; i ++ ) {
+
+					if ( i % 2 === 0 ) {
+
+						newIndices.push( index.getX( i ) );
+						newIndices.push( index.getX( i + 1 ) );
+						newIndices.push( index.getX( i + 2 ) );
+
+
+					} else {
+
+						newIndices.push( index.getX( i + 2 ) );
+						newIndices.push( index.getX( i + 1 ) );
+						newIndices.push( index.getX( i ) );
+
+					}
+
+				}
+
+			}
+
+			if ( ( newIndices.length / 3 ) !== numberOfTriangles ) {
+
+				console.error( 'THREE.BufferGeometryUtils.toTrianglesDrawMode(): Unable to generate correct amount of triangles.' );
+
+			}
+
+			// build final geometry
+
+			var newGeometry = geometry.clone();
+			newGeometry.setIndex( newIndices );
+			newGeometry.clearGroups();
+
+			return newGeometry;
+
+		} else {
+
+			console.error( 'THREE.BufferGeometryUtils.toTrianglesDrawMode(): Unknown draw mode:', drawMode );
+			return geometry;
+
+		}
+
 	}
 
 };


### PR DESCRIPTION
moonrider is broken in browser that have deprecated WebVR because it uses a deprecated WebXR interface. 
This change upgrades the version of aframe which uses the current WebXR interface. 