### PR TITLE
Fixing immersive webxr session dialog issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   </head>
   <body>
     <div id="app"></div>
-    <a id="vrButton" href="#" title="Enter VR / Fullscreen"><p>Click Here to Enter VR</p></a>
+    <div id="vrButton" title="Enter VR / Fullscreen"><p>Click Here to Enter VR</p></div>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-111391431-16"></script>
     <script>


### PR DESCRIPTION
This is a potential fix for the issue raised by @dmarcos : "You will see the prompt Block / Allow flashing quickly and disappearing. The user doesn't have a chance to click on it to be able to enter VR."

After investigating, it seems to me that the issue here is your custom enterVR button is a link <a, which when clicked will refresh the page, improperly dismissing the immersive webxr session prompt dialog, thus preventing user to approve and enter vr. Changing that element to a <div, or anything else fixed the problem for me. Please test this out and see if it fixes the issue entirely.