### PR TITLE
Mines are unhittable

### DIFF
--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -431,7 +431,10 @@ AFRAME.registerComponent('beat', {
     this.bbox = mesh.geometry.boundingBox;
 
     if (this.data.type === 'mine') {
-      this.bbox.expandByScalar(-0.25);
+      const expand = new THREE.Vector3();
+      this.bbox.getSize(expand);
+      expand.multiplyScalar(-0.25);
+      this.bbox.expandByVector(expand);
     }
   },
 


### PR DESCRIPTION
The original code was using `this.bbox.expandByScalar(-0.25);` to decrease the size of mines (for reasons I was unable to determine), but the bbox is only 0.328 large in the x direction and this trims 0.25 from all sides, resulting in an inverted bbox. The z direction is even smaller, with an extent of only 0.05 or so, so on the assumption that the code was meant to reduce the size of the bomb by 50% it now shrinks the dimensions separately.

This code was originally added in 7074c8bb by @ngokevin , so maybe they can say what the intent of this change was.

The bug and the fix were tested on Oculus Quest 2 / Oculus Browser.