### PR TITLE
support "mapping extensions" beatmaps

### DIFF
--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -203,9 +203,9 @@ AFRAME.registerComponent('beat-system', {
     }
   },
 
-  horizontalPositions: {},
+  horizontalPositioning: {},
 
-  verticalPositions: {},
+  verticalPositioning: {},
 
   /**
    * Update positioning between blocks, vertically and horizontally depending on
@@ -226,8 +226,8 @@ AFRAME.registerComponent('beat-system', {
 
     return function () {
       const gameMode = this.data.gameMode;
-      const horizontalPositions = this.horizontalPositions;
-      const verticalPositions = this.verticalPositions;
+      const horizontalPositioning = this.horizontalPositioning;
+      const verticalPositioning = this.verticalPositioning;
 
       const heightOffset = this.el.sceneEl.camera.el.object3D.position.y - REFERENCE_HEIGHT;
       const size = SIZES[gameMode];
@@ -236,26 +236,17 @@ AFRAME.registerComponent('beat-system', {
       // of extra margin.
       // For punch mode, we want a wider horizontal spread in punch range, but not vertical.
       const hMargin = gameMode === CLASSIC ? size : size * 1.2;
-      horizontalPositions.left = -1.5 * hMargin;
-      horizontalPositions.middleleft = -0.5 * hMargin;
-      horizontalPositions.middle = hMargin;
-      horizontalPositions.middleright = 0.5 * hMargin;
-      horizontalPositions.right = 1.5 * hMargin;
+      horizontalPositioning.scale = hMargin;
+      horizontalPositioning.offset = -1.5 * hMargin;
 
       // Vertical margin based on size of blocks so they don't overlap.
       // And then overall shifted up and down based on user height (camera Y).
       // But not too low to go underneath the ground.
       const bottomHeight = BOTTOM_HEIGHTS[gameMode];
       const vMargin = size;
-      verticalPositions.bottom = Math.max(
-        BOTTOM_HEIGHT_MIN,
-        bottomHeight + heightOffset);
-      verticalPositions.middle = Math.max(
-        BOTTOM_HEIGHT_MIN + vMargin,
-        bottomHeight + vMargin + heightOffset);
-      verticalPositions.top = Math.max(
-        BOTTOM_HEIGHT_MIN + vMargin * 2,
-        bottomHeight + (vMargin * 2) + heightOffset);
+      const vOffset = Math.max(BOTTOM_HEIGHT_MIN, bottomHeight + heightOffset);
+      verticalPositioning.scale = vMargin;
+      verticalPositioning.offset = vOffset;
     };
   })(),
 
@@ -299,7 +290,7 @@ AFRAME.registerComponent('beat', {
     this.rigContainer = document.getElementById('rigContainer');
     this.superCuts = document.querySelectorAll('.superCutFx');
 
-    this.verticalPositions = this.beatSystem.verticalPositions;
+    this.verticalPositioning = this.beatSystem.verticalPositioning;
 
     this.explodeEventDetail = {
       beatDirection: '',
@@ -394,7 +385,8 @@ AFRAME.registerComponent('beat', {
     const supercurve = this.curveEl.components.supercurve;
     supercurve.getPointAt(songPosition, el.object3D.position);
     supercurve.alignToCurve(songPosition, el.object3D);
-    el.object3D.position.x += this.beatSystem.horizontalPositions[horizontalPosition];
+    el.object3D.position.x += this.beatSystem.horizontalPositioning.scale * horizontalPosition +
+      this.beatSystem.horizontalPositioning.offset;
 
     if (data.type !== DOT) {
       el.object3D.rotation.z = THREE.Math.degToRad(ROTATIONS[cutDirection]);
@@ -409,7 +401,8 @@ AFRAME.registerComponent('beat', {
     const offset = 0.5;
     el.object3D.position.y -= offset;
     this.positionStart = el.object3D.position.y;
-    this.positionChange = this.verticalPositions[verticalPosition] + offset + heightOffset;
+    this.positionChange = this.verticalPositioning.scale * verticalPosition +
+      this.verticalPositioning.offset + offset + heightOffset;
   },
 
   /**

--- a/src/components/debug-beat-positioning.js
+++ b/src/components/debug-beat-positioning.js
@@ -1,5 +1,5 @@
-const horizontalPositions = ['left', 'middleleft', 'middleright', 'right'];
-const verticalPositions = ['bottom', 'middle', 'top'];
+const horizontalPositions = [0, 1, 2, 3];
+const verticalPositions = [0, 1, 2];
 
 /**
  * Display all beat positions at once.

--- a/src/components/plume.js
+++ b/src/components/plume.js
@@ -2,17 +2,13 @@ AFRAME.registerComponent('plume', {
   schema: {
     color: {default: ''},
     cutDirection: {default: ''},
-    horizontalPosition: {default: 'middleleft', oneOf: ['left', 'middleleft', 'middleright', 'right']},
     songPosition: {default: 0},
     type: {default: 'arrow', oneOf: ['arrow', 'dot', 'mine']},
-    verticalPosition: {default: 'middle', oneOf: ['bottom', 'middle', 'top']}
   },
 
-  horizontalPositions: {
-    left: -0.95,
-    middleleft: -0.6,
-    middleright: 0.6,
-    right: 0.95
+  getHorizontalPosition: noteSpace => {
+    const centered = noteSpace - 1.5;
+    return centered < 0 ? 0.35 * centered - 0.425 : 0.35 * centered + 0.425;
   },
 
   init: function () {
@@ -20,7 +16,7 @@ AFRAME.registerComponent('plume', {
     this.curveFollowRig = document.getElementById('curveFollowRig');
     this.handsEls = this.el.sceneEl.querySelectorAll('.handStar');
     this.handPos = new THREE.Vector3();
-    this.verticalPositions = this.el.sceneEl.components['beat-system'].verticalPositions;
+    this.verticalPositioning = this.el.sceneEl.components['beat-system'].verticalPositioning;
 
     this.el.sceneEl.addEventListener('cleargame', this.returnToPool.bind(this));
   },
@@ -34,14 +30,14 @@ AFRAME.registerComponent('plume', {
   },
 
   onGenerate: function (songPosition, horizontalPosition, verticalPosition, heightOffset) {
-    const data = this.data;
     const el = this.el;
     // Set position.
     const supercurve = this.curveEl.components.supercurve;
     supercurve.getPointAt(songPosition, el.object3D.position);
     supercurve.alignToCurve(songPosition, el.object3D);
-    el.object3D.position.x += this.horizontalPositions[horizontalPosition];
-    el.object3D.position.y += this.verticalPositions[verticalPosition] + heightOffset;
+    el.object3D.position.x += this.getHorizontalPosition(horizontalPosition);
+    el.object3D.position.y += this.verticalPositioning.scale * verticalPosition +
+      this.verticalPositioning.offset + heightOffset;
     el.object3D.rotation.z = Math.random() * Math.PI * 2;
 
     this.songPosition = songPosition;

--- a/src/components/wall.js
+++ b/src/components/wall.js
@@ -74,8 +74,8 @@ AFRAME.registerComponent('wall', {
       // Offset vectors to get the left / right vertex points to pass into curve helper.
       // Note that curve is upside down so the positions are reversed...normally, this would
       // read as `+ (width / 2) - 0.25`.
-      const centerPosition = (-1 * beatSystem.horizontalPositions[horizontalPosition]) -
-        (width / 2) + 0.25;
+      const origPosition = beatSystem.horizontalPositioning.scale * horizontalPosition + beatSystem.horizontalPositioning.offset;
+      const centerPosition = (-1 * origPosition) - (width / 2) + 0.25;
       left.x = centerPosition - (width / 2);
       right.x = centerPosition + (width / 2);
 

--- a/src/workers/zip.js
+++ b/src/workers/zip.js
@@ -87,6 +87,10 @@ addEventListener('message', function (evt) {
                 const id = beatmapCharacteristicName + '-' + difficulty;
                 if (data.beats[id] === undefined) {
                   data.beats[id] = beatFiles[beatmapFilename];
+
+                  data.beats[id].mappingExtensions =
+                    Array.isArray(difficultyBeatmap._customData._requirements) &&
+                    difficultyBeatmap._customData._requirements.includes('Mapping Extensions');
                 }
               }
             }


### PR DESCRIPTION
Some maps like `Shirobon - Into the Zone` make use of the `Mapping Extensions` add-on(?), in which `_lineIndex` and `_lineLayer` are not in the range 0..3, 0..2 but are instead more than 1000. The explanation of the mapping is given [here](https://github.com/bsmg/beatmapper/blob/f9d690313530d8c9253f4eaec338d41077293073/src/helpers/notes.helpers.js#L228-L254), which has been copied into this code.

I had to remove the indirection through `horizontalPositionsHumanized`, because it does not generalize well to notes at fractional positions. Other mappings have been converted to linear functions as appropriate.