### PR TITLE
make the super-keyboard work on desktop

### DIFF
--- a/src/components/super-keyboard.js
+++ b/src/components/super-keyboard.js
@@ -109,14 +109,36 @@ AFRAME.registerComponent('super-keyboard', {
     this.keyHoverColor = new THREE.Color();
     this.keyPressColor = new THREE.Color();
 
-    var self = this;
-    document.addEventListener('keydown', function (ev) {
-      if (ev.key === 't') {
-        var ss = '';
-        var s = 'abcdefghijklmopqrstuvQWIEUTGASDLIGKBXACQWETL102394676457';
-        var l = Math.floor(Math.random() * 20);
-        for (var i = 0; i < l; i++) ss += s[Math.floor(Math.random() * s.length)];
-        self.el.setAttribute('super-keyboard', {value: ss});
+    document.addEventListener('keydown', ev => {
+      // if (ev.key === 't') {
+      //   var ss = '';
+      //   var s = 'abcdefghijklmopqrstuvQWIEUTGASDLIGKBXACQWETL102394676457';
+      //   var l = Math.floor(Math.random() * 20);
+      //   for (var i = 0; i < l; i++) ss += s[Math.floor(Math.random() * s.length)];
+      //   this.el.setAttribute('super-keyboard', { value: ss });
+      // }
+
+      if (ev.key.length == 1) {
+        const key = ev.key.toLowerCase();
+        if (!'abcdefghijklmnopqrstuvwxyz '.includes(key)) { return; }
+        if (this.data.maxLength > 0 && this.rawValue.length > this.data.maxLength) { return; }
+        this.rawValue += key;
+        var newValue = this.filter(this.rawValue);
+        this.el.setAttribute('super-keyboard', 'value', newValue);
+        this.updateTextInput(newValue);
+        this.changeEventDetail.value = newValue;
+        this.el.emit('superkeyboardchange', this.changeEventDetail);
+      } else if (ev.key == 'Shift') {
+        this.shift = !this.shift;
+      } else if (ev.key == 'Backspace') {
+        this.rawValue = this.rawValue.substr(0, this.rawValue.length - 1);
+        var newValue = this.filter(this.rawValue);
+        this.el.setAttribute('super-keyboard', 'value', newValue);
+        this.updateTextInput(newValue);
+        this.changeEventDetail.value = newValue;
+        this.el.emit('superkeyboardchange', this.changeEventDetail);
+      } else if (ev.key == 'Escape') {
+        this.dismiss();
       }
     });
 


### PR DESCRIPTION
You can't use the keyboard when not in VR currently. There is a debug setting `DEBUG_KEYBOARD` that allows you to click on the buttons manually it but this breaks it in VR, because it just switches the input method and then the laser pointers don't work. This is not a perfect implementation since it doesn't disable the usage of keys for other things (e.g. pressing 'A' will cause you to walk to the left and also type an 'A' in the keyboard), but at least it isn't unusable.