### PR TITLE
sanitize some null/nan values

### DIFF
--- a/src/components/beat-generator.js
+++ b/src/components/beat-generator.js
@@ -160,6 +160,9 @@ AFRAME.registerComponent('beat-generator', {
     // Beats spawn ahead of the song and get to the user in sync with the music.
     this.songTime = 0;
     this.preloadTime = 0;
+    this.beatData._events = this.beatData._events || [];
+    this.beatData._obstacles = this.beatData._obstacles || [];
+    this.beatData._notes = this.beatData._notes || [];
     this.beatData._events.sort(lessThan);
     this.beatData._obstacles.sort(lessThan);
     this.beatData._notes.sort(lessThan);

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -712,9 +712,9 @@ AFRAME.registerState({
       state.search.urlPage = payload.urlPage;
       state.search.query = payload.query;
       state.search.queryText = truncate(payload.query, 10);
-      state.search.results = payload.results;
-      for (i = 0; i < payload.results.length; i++) {
-        let result = payload.results[i];
+      state.search.results = payload.results || [];
+      for (i = 0; i < state.search.results.length; i++) {
+        let result = state.search.results[i];
         // result.songSubName = result.songSubName || 'Unknown Artist';
         // result.shortSongName = truncate(result.songName, SONG_NAME_TRUNCATE).toUpperCase();
         // result.shortSongSubName = truncate(result.songSubName, SONG_SUB_NAME_RESULT_TRUNCATE);
@@ -995,6 +995,7 @@ function updateScoreAccuracy(state) {
   // Update live accuracy.
   const currentNumBeats = state.score.beatsHit + state.score.beatsMissed;
   state.score.accuracy = (state.score.accuracyScore / (currentNumBeats * 100)) * 100;
+  state.score.accuracy = isNaN(state.score.accuracy) ? 100 : state.score.accuracy;
   state.score.accuracy = state.score.accuracy.toFixed(2);
   state.score.accuracyInt = parseInt(state.score.accuracy);
 }


### PR DESCRIPTION
* Some songs which have no events / obstacles / notes omit the corresponding field instead of sending `[]`, so sanitize that
* On first run the favorites will be undefined, resulting in a call to `search` with a null `payload.results`
* The song accuracy displays as `NaN%` if the song has no notes (rare but present in some meme tracks); treat this like 100%, similar to the initial score percent.