### PR TITLE
disable off-hand in OneSaber mode

### DIFF
--- a/src/components/beat-generator.js
+++ b/src/components/beat-generator.js
@@ -25,6 +25,7 @@ AFRAME.registerComponent('beat-generator', {
   schema: {
     challengeId: { type: 'string' }, // If clicked play.
     gameMode: { type: 'string' }, // classic, punch, ride.
+    leftHandedMode: { default: false },
     difficulty: { type: 'string' },
     beatmapCharacteristic: { type: 'string' },
     has3DOFVR: { default: false },
@@ -252,9 +253,9 @@ AFRAME.registerComponent('beat-generator', {
     let color;
     let type = noteInfo._cutDirection === 8 ? 'dot' : 'arrow';
     if (noteInfo._type === 0) {
-      color = 'red';
+      color = data.leftHandedMode ? 'blue' : 'red';
     } else if (noteInfo._type === 1) {
-      color = 'blue';
+      color = data.leftHandedMode ? 'red' : 'blue';
     } else {
       type = 'mine';
       color = undefined;
@@ -286,7 +287,10 @@ AFRAME.registerComponent('beat-generator', {
 
     // Apply sword offset. Blocks arrive on beat in front of the user.
     const cutDirection = this.orientationsHumanized[noteInfo._cutDirection];
-    const horizontalPosition = this.horizontalPositionsHumanized[noteInfo._lineIndex] || 'left';
+    let lineIndex = noteInfo._lineIndex;
+    // mirror notes in OneSaber left handed mode
+    if (data.leftHandedMode) lineIndex = 3 - lineIndex;
+    const horizontalPosition = this.horizontalPositionsHumanized[lineIndex] || 'left';
     const verticalPosition = this.verticalPositionsHumanized[noteInfo._lineLayer] || 'middle';
 
     // Factor in sword offset and beat anticipation time (percentage).
@@ -336,7 +340,10 @@ AFRAME.registerComponent('beat-generator', {
     if (data.has3DOFVR && data.gameMode !== 'viewer') { return; }
 
     const durationSeconds = 60 * (wallInfo._duration / this.bpm);
-    const horizontalPosition = this.horizontalPositionsHumanized[wallInfo._lineIndex] || 'none';
+    let lineIndex = wallInfo._lineIndex;
+    // mirror obstacles in OneSaber left handed mode
+    if (data.leftHandedMode) lineIndex = 3 - lineIndex;
+    const horizontalPosition = this.horizontalPositionsHumanized[lineIndex] || 'none';;
     const isCeiling = wallInfo._type === 1;
     const length = durationSeconds * data.speed;
     const width = wallInfo._width / 2; // We want half the reported width.
@@ -385,10 +392,10 @@ AFRAME.registerComponent('beat-generator', {
         this.tube.emit('pulse', null, false);
         break;
       case 12:
-        this.stageColors.setColor('leftglow', event._value);
+        this.stageColors.setColor(this.data.leftHandedMode ? 'rightglow' : 'leftglow', event._value);
         break;
       case 13:
-        this.stageColors.setColor('rightglow', event._value);
+        this.stageColors.setColor(this.data.leftHandedMode ? 'leftglow' : 'rightglow', event._value);
         break;
     }
   },

--- a/src/components/blade.js
+++ b/src/components/blade.js
@@ -89,7 +89,7 @@ AFRAME.registerComponent('blade', {
     const RIGHT = 'right';
 
     return function (beat) {
-      if (this.strokeSpeed < 1) { return false; }
+      if (!this.data.enabled || this.strokeSpeed < 1) { return false; }
 
       // Convert points to beat space.
       for (let i = 0; i < 3; i++) {

--- a/src/scene.html
+++ b/src/scene.html
@@ -5,7 +5,7 @@
 {% set firekey = true and 'AIzaSyAilakXLvMgwPcBcHs3oys51eLp4yrfz0w' or 'AIzaSyALCaDKg0b7aD3nOyRv_f5RTZ1vedrGyWw' %}
 
 <a-scene
-  bind__beat-generator="challengeId: challenge.id; difficulty: challenge.difficulty; beatmapCharacteristic: challenge.beatmapCharacteristic; gameMode: gameMode; has3DOFVR: has3DOFVR; hasSongLoadError: hasSongLoadError; isPlaying: isPlaying; isZipFetching: isZipFetching; menuSelectedChallengeId: menuSelectedChallenge.id; songDuration: challenge.metadata.duration; speed: speed"
+  bind__beat-generator="challengeId: challenge.id; difficulty: challenge.difficulty; beatmapCharacteristic: challenge.beatmapCharacteristic; gameMode: gameMode; leftHandedMode: challenge.leftHandedMode; has3DOFVR: has3DOFVR; hasSongLoadError: hasSongLoadError; isPlaying: isPlaying; isZipFetching: isZipFetching; menuSelectedChallengeId: menuSelectedChallenge.id; songDuration: challenge.metadata.duration; speed: speed"
   bind__beat-system="gameMode: gameMode; hasVR: hasVR; isLoading: isLoading; isPlaying: isPlaying"
   bind__gameover="isGameOver: isGameOver"
   bind__intro-song="isPlaying: menuActive && !menuSelectedChallenge.id; isSearching: isSearching"

--- a/src/scene.html
+++ b/src/scene.html
@@ -154,19 +154,21 @@
       id="controllerRig"
       proxy-event="event: recentered; to: #cameraRig; captureBubbles: true; as: recenter">
       {% macro weapon (hand, otherHand) %}
+        {% set active = "(challenge.beatmapCharacteristic != 'OneSaber' || " + ("!" if hand != "left") + "challenge.leftHandedMode)" %}
         <a-entity id="{{ hand }}Hand"
           class="weapon"
           bind__hand-swapper="enabled: {{ otherHand }}RaycasterActive"
-          bind__haptics-wall="enabled: isPlaying && gameMode === 'classic'"
+          bind__haptics="enabled: !isPlaying || {{ active }}"
+          bind__haptics-wall="enabled: isPlaying && gameMode === 'classic' && {{ active }}"
           bind__headfist="isPlaying: isPlaying"
           bind__menu-controls="enabled: mainMenuActive"
           bind__pauser="enabled: isPlaying"
           bind__punch="enabled: isPlaying && gameMode === 'punch'"
           bind__raycaster="enabled: {{ hand }}RaycasterActive"
           bind__raycaster__game="enabled: isPlaying && (gameMode === 'classic' || gameMode === 'punch')"
-          bind__blade="enabled: isPlaying && gameMode === 'classic'"
-          bind__weapon-particles="enabled: isPlaying; gameMode: gameMode"
-          bind__trail="colorScheme: colorScheme; enabled: isPlaying && gameMode === 'classic'"
+          bind__blade="enabled: isPlaying && gameMode === 'classic' && {{ active }}"
+          bind__weapon-particles="enabled: isPlaying && {{ active }}; gameMode: gameMode"
+          bind__trail="colorScheme: colorScheme; enabled: isPlaying && gameMode === 'classic' && {{ active }}"
           controller="hand: {{ hand }}"
           data-hand="{{ hand }}"
           haptics="events: mouseenter; dur: 35; force: 0.075"
@@ -198,7 +200,7 @@
                     bind__rotation="controllerType.indexOf('oculus') !== -1 && '135 0 0' || '90 0 0'">
             <a-entity
               class="bladeContainer"
-              bind__visible="isPlaying && gameMode === 'classic'"
+              bind__visible="isPlaying && gameMode === 'classic' && {{ active }}"
               animation="property: scale; from: 0 0 0; to: 1 1 1; dur: 750; easing: linear; startEvents: drawblade"
               scale="0.001 0.001 0.001">
               <a-entity
@@ -213,7 +215,7 @@
 
             <a-entity
               class="bladeHandle"
-              bind__visible="!isPlaying || gameMode === 'classic'"
+              bind__visible="!isPlaying || gameMode === 'classic' && {{ active }}"
               obj-model="obj: #weaponHandleObj"
               materials="name: {{ hand }}WeaponHandle">
               <a-entity class="bladeHandleHelper"></a-entity>
@@ -225,7 +227,7 @@
             id="{{ hand }}punch"
             class="punch"
             render-order="weapon"
-            bind__visible="isPlaying && gameMode === 'punch'"
+            bind__visible="isPlaying && gameMode === 'punch' && {{ active }}"
             bind__position="has3DOFVR && '0 0 -0.75' || '0 0 0'"
             rotation="0 0 0">
               <a-entity
@@ -249,7 +251,7 @@
             id="{{ hand }}star"
             class="handStar"
             render-order="weapon"
-            bind__visible="isPlaying && gameMode === 'ride'">
+            bind__visible="isPlaying && gameMode === 'ride' && {{ active }}">
               <a-entity
                 class="handStar"
                 bind__material="colorPrimary: colorPrimary; colorSecondary: colorSecondary; colorTertiary: colorTertiary"

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -73,6 +73,7 @@ AFRAME.registerState({
       id: AFRAME.utils.getUrlParameter('challenge'),  // Will be empty string if not playing.
       image: '',
       isBeatsPreloaded: false,  // Whether we have passed the negative time.
+      leftHandedMode: false,
       numBeats: undefined,
       songDuration: 0,
       songName: '',
@@ -374,6 +375,7 @@ AFRAME.registerState({
 
     gamemenurestart: state => {
       resetScore(state);
+      setLeftHandedMode(state);
       state.challenge.isBeatsPreloaded = false;
       state.isGameOver = false;
       state.isPaused = false;
@@ -623,6 +625,8 @@ AFRAME.registerState({
 
       // Set challenge.
       Object.assign(state.challenge, state.menuSelectedChallenge);
+
+      setLeftHandedMode(state);
 
       gtag('event', 'difficulty', { event_label: state.challenge.difficulty });
 
@@ -952,6 +956,12 @@ function resetScore(state) {
   state.score.combo = 0;
   state.score.maxCombo = 0;
   state.score.score = 0;
+}
+
+function setLeftHandedMode(state) {
+  state.challenge.leftHandedMode =
+    state.challenge.beatmapCharacteristic == 'OneSaber' &&
+    state.activeHand == 'left';
 }
 
 function computeMenuSelectedChallengeIndex(state) {


### PR DESCRIPTION
* [ ] depends on: #198 

This completely hides the off-hand and disables all feedback for it when in OneSaber mode; otherwise it's just an awkward thing you have to keep out of the way while playing. (This can be separated from #198 but they interact slightly so it seemed better to base this on that PR.)